### PR TITLE
Fix all open QA issues: signup, auth, emails, exports

### DIFF
--- a/backend/src/controllers/accountantController.js
+++ b/backend/src/controllers/accountantController.js
@@ -139,7 +139,7 @@ const exportClient = async (req, res) => {
 
         const expenses = await expenseModel.getExpensesByOrgIdAndYear(req.pool, clientOrgId, year);
         if (expenses.length === 0) {
-            return res.status(404).json({ message: 'No transactions found for the given client and year.' });
+            return res.status(404).json({ error: 'No transactions found for the given client and year.' });
         }
 
         // The tax-season pack: Form 11 buckets, capital-allowances schedule and

--- a/backend/src/controllers/expenseController.js
+++ b/backend/src/controllers/expenseController.js
@@ -390,7 +390,7 @@ const getExcelDownloadByUserIdAndYear = async (req, res) => {
 
         const expenses = await expenseModel.getExpensesByUserIdAndYear(pool, userId, year, scopeOrgIdFor(req));
         if (expenses.length === 0) {
-            return res.status(404).json({ message: 'No expenses found for the given user and year.' });
+            return res.status(404).json({ error: 'No expenses found for the given user and year.' });
         }
 
         await downloadImages(expenses, imagesDir);

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,7 +1,6 @@
 
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
-const nodemailer = require('nodemailer');
 require('dotenv').config();
 const userModel = require('../models/userModel');
 const organisationModel = require('../models/organisationModel');
@@ -11,35 +10,44 @@ const { uploadBase64Image } = require('../middlewares/imageUpload');
 const moment = require('moment');
 const { v4: uuidv4 } = require('uuid');
 const gf = require('../utils/gf');
+const { sendEmail } = require('../utils/email');
 const { BRAND } = require('../config/brand');
 const { isSuperAdmin } = require('../middlewares/tenantScope');
 
 const jwtSecret = process.env.JWT_SECRET;
 const frontendURL = process.env.FRONTEND_URL;
 
-// Shared invite email sender for both invite kinds (member + client). Keeps the
-// Gmail transport config in one place. Throws on send failure so callers decide
-// how to respond.
+// Password strength policy, mirrored by the signup form's live checklist.
+// Client-side rules are bypassable with a direct API call, so the endpoints
+// that set a password (register, reset) are the real enforcement point.
+const PASSWORD_RULES = [
+    { label: 'at least 8 characters', test: (pw) => pw.length >= 8 },
+    { label: 'a lowercase letter', test: (pw) => /[a-z]/.test(pw) },
+    { label: 'an uppercase letter', test: (pw) => /[A-Z]/.test(pw) },
+    { label: 'a number', test: (pw) => /[0-9]/.test(pw) },
+    { label: 'a symbol', test: (pw) => /[^A-Za-z0-9]/.test(pw) },
+];
+const passwordPolicyError = (password) => {
+    const unmet = PASSWORD_RULES.filter((rule) => !rule.test(String(password ?? '')));
+    if (unmet.length === 0) return null;
+    return `Password must contain ${unmet.map((rule) => rule.label).join(', ')}.`;
+};
+
+// Shared invite email sender for both invite kinds (member + client). All
+// formatting/transport lives in utils/email so every mail matches the app
+// theme. Throws on send failure so callers decide how to respond.
 const sendInviteEmail = async (email, inviteLink) => {
-    const transporter = nodemailer.createTransport({
-        service: 'Gmail',
-        host: 'smtp.gmail.com',
-        port: 465,
-        secure: true,
-        auth: {
-            user: process.env.EMAIL_USERNAME,
-            pass: process.env.EMAIL_PASSWORD,
-        },
-    });
-
-    const mailOptions = {
-        from: process.env.EMAIL_USERNAME,
+    await sendEmail({
         to: email,
-        subject: 'You have been invited to create an account!',
+        subject: `You've been invited to join ${BRAND}`,
+        heading: "You're invited",
+        paragraphs: [
+            `You have been invited to create an account with ${BRAND} - a simple way to track expenses and stay on top of your books.`,
+        ],
+        cta: { label: 'Create your account', url: inviteLink },
+        footerNote: 'You received this because someone invited this address to their organisation.',
         text: `You have been invited to create an account with ${BRAND}. Click the link to create your account: ${inviteLink}`,
-    };
-
-    await transporter.sendMail(mailOptions);
+    });
 };
 
 // Phase 6 email verification. Self-serve signups must confirm their address
@@ -57,21 +65,16 @@ const sendVerificationEmail = async (email) => {
     const backendBase = (process.env.PUBLIC_BACKEND_URL || `http://localhost:${process.env.PORT || 8080}`).replace(/\/$/, '');
     const verifyLink = `${backendBase}/users/verify-email?token=${verifyToken}`;
 
-    const transporter = nodemailer.createTransport({
-        service: 'Gmail',
-        host: 'smtp.gmail.com',
-        port: 465,
-        secure: true,
-        auth: {
-            user: process.env.EMAIL_USERNAME,
-            pass: process.env.EMAIL_PASSWORD,
-        },
-    });
-
-    await transporter.sendMail({
-        from: process.env.EMAIL_USERNAME,
+    await sendEmail({
         to: email,
         subject: `Verify your ${BRAND} email address`,
+        heading: 'Confirm your email address',
+        paragraphs: [
+            `Welcome to ${BRAND}! Please confirm your email address to finish setting up your account.`,
+            'The link is valid for 24 hours - if it expires, you can request a new one from the app.',
+        ],
+        cta: { label: 'Verify email address', url: verifyLink },
+        footerNote: `You received this because this address was used to sign up to ${BRAND}.`,
         text: `Welcome to ${BRAND}! Please confirm your email address by clicking this link (valid for 24 hours): ${verifyLink}\n\nIf the link expires, you can request a new one from the app.`,
     });
 };
@@ -395,6 +398,12 @@ const register = async (req, res) => {
         });
     }
 
+    const passwordError = passwordPolicyError(password);
+    if (passwordError) {
+        logger.warn('Registration rejected for weak password: %s', email);
+        return res.status(400).json({ error: passwordError });
+    }
+
     let mode = 'self';
     let inviterId = null;
     let accountantOrgId = null;
@@ -523,37 +532,38 @@ const dashboardLogin = async (req, res) => {
     }
 };
 
+// Answers 200 with the same message whether or not the account exists - a 404
+// here would let anyone probe which emails have accounts (matches the
+// enumeration-safe contract of resend-verification).
 const requestPasswordReset = async (req, res) => {
     const { email } = req.body;
+    const genericMessage = 'If an account exists for that address, a reset link is on its way.';
 
     try {
         const user = await userModel.getUserByEmail(req.pool, email);
         if (!user) {
             logger.warn('Password reset requested for non-existing user: %s', email);
-            return res.status(404).json({ error: 'User not found.' });
+            return res.status(200).json({ message: genericMessage });
         }
 
         const resetToken = jwt.sign({ userId: user.id }, jwtSecret, { expiresIn: '1h' });
 
         const resetLink = `${frontendURL}/reset-password?token=${resetToken}`;
-        const transporter = nodemailer.createTransport({
-            service: 'gmail',
-            auth: {
-                user: process.env.EMAIL_USERNAME,
-                pass: process.env.EMAIL_PASSWORD,
-            },
-        });
-        const mailOptions = {
-            from: process.env.EMAIL_USERNAME,
+        await sendEmail({
             to: email,
-            subject: 'Password Reset',
+            subject: `Reset your ${BRAND} password`,
+            heading: 'Reset your password',
+            paragraphs: [
+                `We received a request to reset the password for your ${BRAND} account.`,
+                'The link is valid for 1 hour. If you did not request this, you can safely ignore this email.',
+            ],
+            cta: { label: 'Reset password', url: resetLink },
+            footerNote: 'You received this because a password reset was requested for this address.',
             text: `You requested a password reset. Click the link to reset your password: ${resetLink}`,
-        };
-        
-        await transporter.sendMail(mailOptions);
+        });
 
         logger.info('Password reset email sent to: %s', email);
-        res.status(200).json({ message: 'Password reset email sent.' });
+        res.status(200).json({ message: genericMessage });
     } catch (error) {
         logger.error('Error requesting password reset: %s', error.message);
         res.status(500).json({ error: 'Internal server error.' });
@@ -563,8 +573,24 @@ const requestPasswordReset = async (req, res) => {
 const resetPassword = async (req, res) => {
     const { token, newPassword } = req.body;
 
+    // Same policy as register - otherwise the reset flow would let a weak
+    // password back in through the side door.
+    const passwordError = passwordPolicyError(newPassword);
+    if (passwordError) {
+        return res.status(400).json({ error: passwordError });
+    }
+
+    // A bad or expired token is the user's most likely failure (the link is
+    // only valid for 1 hour) - answer 400 with a actionable message, not 500.
+    let decoded;
     try {
-        const decoded = jwt.verify(token, jwtSecret);
+        decoded = jwt.verify(token, jwtSecret);
+    } catch (error) {
+        logger.warn('Invalid password reset token: %s', error.message);
+        return res.status(400).json({ error: 'This reset link is invalid or has expired - request a new one.' });
+    }
+
+    try {
         const user = await userModel.getUserById(req.pool, decoded.userId);
         if (!user) {
             logger.warn('Password reset attempted for non-existing user: %s', decoded.userId);
@@ -648,41 +674,21 @@ const sendSupportEmail = async (req, res) => {
     }
 
     try {
-      const transporter = nodemailer.createTransport({
-        service: 'Gmail',
-        host: 'smtp.gmail.com',
-        port: 465,
-        secure: true,
-        auth: {
-          user: process.env.EMAIL_USERNAME,
-          pass: process.env.EMAIL_PASSWORD,
-        },
+      // Internal mail (to the support inbox), but branded like the rest so
+      // the details are easy to scan.
+      await sendEmail({
+        to: process.env.EMAIL_USERNAME,
+        subject: `Support request from ${userEmail}`,
+        heading: 'New support request',
+        paragraphs: [
+          `From: ${userEmail}`,
+          `Issue type: ${issueType}`,
+          issueDescription,
+        ],
+        text: `A user has requested support. Details below:\n\nFrom: ${userEmail}\nIssue Type: ${issueType}\n\nIssue Description:\n${issueDescription}`,
       });
-  
-      const mailOptions = {
-        from: process.env.EMAIL_USERNAME,
-        to: process.env.EMAIL_USERNAME, 
-        subject: `Support Request from ${userEmail}`,
-        text: `
-        A user has requested support. Details below:
-
-        From: ${userEmail}
-        Issue Type: ${issueType}
-
-        Issue Description:
-        ${issueDescription}
-        `,
-      };
-  
-      transporter.sendMail(mailOptions, (error, info) => {
-        if (error) {
-          logger.error('Error sending support email:', error);
-          return res.status(500).json({ error: 'Error sending support email.' });
-        } else {
-          logger.info('Support email sent:', info.response);
-          return res.status(200).json({ message: 'Support request sent successfully.' });
-        }
-      });
+      logger.info('Support email sent for %s', userEmail);
+      return res.status(200).json({ message: 'Support request sent successfully.' });
     } catch (error) {
       logger.error('Error in sendSupportEmail:', error.message);
       return res.status(500).json({ error: 'Internal server error.' });

--- a/backend/src/middlewares/authMiddleware.js
+++ b/backend/src/middlewares/authMiddleware.js
@@ -1,5 +1,7 @@
 const jwt = require('jsonwebtoken');
 require('dotenv').config();
+const userModel = require('../models/userModel');
+const logger = require('../utils/logger');
 const jwtSecret = process.env.JWT_SECRET;
 
 const authenticateToken = (req, res, next) => {
@@ -8,7 +10,7 @@ const authenticateToken = (req, res, next) => {
 
     if (!token) return res.sendStatus(401);
 
-    jwt.verify(token, jwtSecret, (err, user) => {
+    jwt.verify(token, jwtSecret, async (err, user) => {
         if (err) return res.status(403).json({ error: 'Access denied. Invalid bearer token.' });
 
         // Backward compatibility: tokens issued before Phase 0 carry no orgId.
@@ -18,6 +20,29 @@ const authenticateToken = (req, res, next) => {
         }
 
         req.user = user;
+
+        // Suspension used to be enforced at login only, so a suspended user's
+        // existing token kept working for up to 7 days. Check per request
+        // (one indexed query). Skipped when no pool is wired (bare unit tests).
+        if (!req.pool) return next();
+        try {
+            const status = await userModel.getAccountStatuses(req.pool, user.userId);
+            if (!status) {
+                // The account no longer exists (e.g. GDPR delete) - the token
+                // must die with it.
+                return res.status(401).json({ error: 'Session out of date, please log in again.' });
+            }
+            if (status.account_status === 'suspended') {
+                return res.status(403).json({ error: 'This account has been suspended. Please contact support.' });
+            }
+            if (status.org_status === 'suspended') {
+                return res.status(403).json({ error: 'This organisation has been suspended. Please contact support.' });
+            }
+        } catch (dbError) {
+            // Fail open: a DB blip here must not lock every user out - the
+            // request will fail downstream anyway if the DB is really gone.
+            logger.warn('Suspension check skipped: %s', dbError.message);
+        }
         next();
     });
 };

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -378,6 +378,25 @@ const getUsersByOrgId = async (pool, orgId) => {
     }
 };
 
+// User + owning-org status in one round trip. Used by the auth middleware's
+// per-request suspension check, so a suspended account/org is cut off
+// immediately instead of riding out its 7-day token.
+const getAccountStatuses = async (pool, userId) => {
+    try {
+        const result = await pool.query(
+            `SELECT u.account_status, o.status AS org_status
+             FROM users u
+             LEFT JOIN organisations o ON o.id = u.org_id
+             WHERE u.id = $1`,
+            [userId]
+        );
+        return result.rows[0] || null;
+    } catch (error) {
+        logger.error('Error fetching account statuses', { userId, error: error.message });
+        throw error;
+    }
+};
+
 // Phase 0 tenant scoping helper: does the given user belong to the given org?
 // Used by controllers to reject cross-org access (403) on by-id endpoints.
 const isUserInOrg = async (pool, userId, orgId) => {
@@ -471,5 +490,6 @@ module.exports = {
     getUsersByOrgId,
     getUserPasswordByEmail,
     updateUserById,
-    isUserInOrg
+    isUserInOrg,
+    getAccountStatuses
 };

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -1,0 +1,115 @@
+// Branded transactional email. Every email the app sends goes through
+// sendEmail so they all share one clean, mobile-friendly layout that matches
+// the app theme (white card on grey, purple wordmark and button - the colour
+// values mirror the tokens in frontend/src/app/globals.css).
+//
+// The transport is created per send, NOT at module load, so tests can stub
+// nodemailer.createTransport. Every send carries a plaintext body alongside
+// the HTML for clients (and tests) that only read text.
+const nodemailer = require('nodemailer');
+const { BRAND } = require('../config/brand');
+
+// Mirrors --primary and the zinc greys in frontend/src/app/globals.css.
+const COLORS = {
+    primary: '#8a3ffc',
+    heading: '#18181b',
+    body: '#3f3f46',
+    muted: '#71717a',
+    border: '#e4e4e7',
+    background: '#f4f4f5',
+    card: '#ffffff',
+};
+
+const FONT_STACK =
+    "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif";
+
+const escapeHtml = (value) =>
+    String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+// Escaped paragraph HTML; user-supplied newlines survive as <br>.
+const paragraphHtml = (text) =>
+    `<p style="margin:0 0 16px;font-size:15px;line-height:1.6;color:${COLORS.body};">${escapeHtml(text).replace(/\n/g, '<br>')}</p>`;
+
+// Table-based layout with inline styles only - the lowest common denominator
+// email clients render reliably.
+const renderEmail = ({ heading, paragraphs = [], cta = null, footerNote = null }) => {
+    const ctaHtml = cta
+        ? `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:8px 0 20px;">
+            <tr>
+              <td style="border-radius:8px;background-color:${COLORS.primary};">
+                <a href="${escapeHtml(cta.url)}" target="_blank"
+                   style="display:inline-block;padding:12px 24px;font-family:${FONT_STACK};font-size:15px;font-weight:600;color:#ffffff;text-decoration:none;border-radius:8px;">
+                  ${escapeHtml(cta.label)}
+                </a>
+              </td>
+            </tr>
+          </table>
+          <p style="margin:0 0 4px;font-size:12px;line-height:1.6;color:${COLORS.muted};">
+            If the button doesn't work, copy and paste this link into your browser:<br>
+            <a href="${escapeHtml(cta.url)}" style="color:${COLORS.primary};word-break:break-all;">${escapeHtml(cta.url)}</a>
+          </p>`
+        : '';
+
+    const footer = footerNote
+        ? `${escapeHtml(footerNote)}<br>`
+        : '';
+
+    return `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background-color:${COLORS.background};">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:${COLORS.background};">
+      <tr>
+        <td align="center" style="padding:32px 16px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:${COLORS.card};border:1px solid ${COLORS.border};border-radius:12px;">
+            <tr>
+              <td style="padding:28px 32px 0;font-family:${FONT_STACK};">
+                <span style="font-size:20px;font-weight:700;letter-spacing:-0.02em;color:${COLORS.primary};">${escapeHtml(BRAND)}</span>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:20px 32px 24px;font-family:${FONT_STACK};">
+                <h1 style="margin:0 0 12px;font-size:20px;font-weight:600;letter-spacing:-0.01em;color:${COLORS.heading};">${escapeHtml(heading)}</h1>
+                ${paragraphs.map(paragraphHtml).join('\n                ')}
+                ${ctaHtml}
+              </td>
+            </tr>
+          </table>
+          <p style="margin:20px 0 0;font-family:${FONT_STACK};font-size:12px;line-height:1.6;color:${COLORS.muted};">
+            ${footer}&copy; ${escapeHtml(BRAND)}
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+};
+
+// Sends a branded email. `text` is the required plaintext fallback and must
+// contain any action link, so text-only clients still get a working email.
+const sendEmail = async ({ to, subject, heading, paragraphs = [], cta = null, footerNote = null, text }) => {
+    const transporter = nodemailer.createTransport({
+        service: 'Gmail',
+        host: 'smtp.gmail.com',
+        port: 465,
+        secure: true,
+        auth: {
+            user: process.env.EMAIL_USERNAME,
+            pass: process.env.EMAIL_PASSWORD,
+        },
+    });
+
+    return transporter.sendMail({
+        from: `"${BRAND}" <${process.env.EMAIL_USERNAME}>`,
+        to,
+        subject,
+        text,
+        html: renderEmail({ heading, paragraphs, cta, footerNote }),
+    });
+};
+
+module.exports = { sendEmail, renderEmail };

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -20,6 +20,9 @@ const logger = createLogger({
     silent: process.env.NODE_ENV === 'test',
     format: format.combine(
         withRequestId(),
+        // util.format-style interpolation: without this, every '%s'/'%o'
+        // placeholder prints literally instead of the value passed for it.
+        format.splat(),
         format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
         format.printf(({ timestamp, level, message, ...meta }) => {
             let log = `[${timestamp}] [${level}]: ${message}`;

--- a/backend/test/tenantIsolation.test.js
+++ b/backend/test/tenantIsolation.test.js
@@ -110,4 +110,79 @@ describe('Tenant isolation', () => {
       expect(req.user.orgId).toBe('org-A');
     });
   });
+
+  // (c) suspension is enforced per request (not just at login), so a
+  // suspended account/org can't ride out its existing 7-day token
+  describe('authenticateToken suspension check', () => {
+    const flush = () => new Promise((resolve) => setImmediate(resolve));
+    const makeReq = () => ({
+      pool: {},
+      headers: {
+        authorization: `Bearer ${jwt.sign({ userId: 'u1', role: 'user', orgId: 'org-A' }, process.env.JWT_SECRET)}`,
+      },
+    });
+
+    it('403s a suspended user mid-session', async () => {
+      sinon.stub(userModel, 'getAccountStatuses').resolves({ account_status: 'suspended', org_status: 'active' });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.stub();
+
+      authenticateToken(req, res, next);
+      await flush();
+
+      expect(res.status.calledWith(403)).toBe(true);
+      expect(next.notCalled).toBe(true);
+    });
+
+    it('403s a member of a suspended org mid-session', async () => {
+      sinon.stub(userModel, 'getAccountStatuses').resolves({ account_status: 'active', org_status: 'suspended' });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.stub();
+
+      authenticateToken(req, res, next);
+      await flush();
+
+      expect(res.status.calledWith(403)).toBe(true);
+      expect(next.notCalled).toBe(true);
+    });
+
+    it('401s when the account no longer exists (deleted mid-session)', async () => {
+      sinon.stub(userModel, 'getAccountStatuses').resolves(null);
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.stub();
+
+      authenticateToken(req, res, next);
+      await flush();
+
+      expect(res.status.calledWith(401)).toBe(true);
+      expect(next.notCalled).toBe(true);
+    });
+
+    it('passes an active user through', async () => {
+      sinon.stub(userModel, 'getAccountStatuses').resolves({ account_status: 'active', org_status: 'active' });
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.stub();
+
+      authenticateToken(req, res, next);
+      await flush();
+
+      expect(next.calledOnce).toBe(true);
+    });
+
+    it('fails open when the status query errors', async () => {
+      sinon.stub(userModel, 'getAccountStatuses').rejects(new Error('db down'));
+      const req = makeReq();
+      const res = makeRes();
+      const next = sinon.stub();
+
+      authenticateToken(req, res, next);
+      await flush();
+
+      expect(next.calledOnce).toBe(true);
+    });
+  });
 });

--- a/backend/test/usercontroller.test.js
+++ b/backend/test/usercontroller.test.js
@@ -99,11 +99,14 @@ describe('User Controller Functions', () => {
 
   // ---- requestPasswordReset ----------------------------------------------
   describe('requestPasswordReset', () => {
-    it('should return 404 if user not found', async () => {
+    it('should return 200 without sending when the user is unknown (no enumeration)', async () => {
       req.body = { email: 'nope@example.com' };
       sinon.stub(userModel, 'getUserByEmail').resolves(null);
+      const sendMail = sinon.stub().resolves(true);
+      sinon.stub(nodemailer, 'createTransport').returns({ sendMail });
       await userController.requestPasswordReset(req, res);
-      expect(res.status.calledWith(404)).toBe(true);
+      expect(res.status.calledWith(200)).toBe(true);
+      expect(sendMail.notCalled).toBe(true);
     });
 
     it('should send a reset email and return 200', async () => {

--- a/docs/qa-test-plan.md
+++ b/docs/qa-test-plan.md
@@ -72,10 +72,10 @@ Personas without seed accounts — create during Suite B: **P1 solo trader** (fr
 
 | # | Steps | Expected |
 |---|---|---|
-| A1 | Open `/` logged out | Landing renders. Header: "For accountants" → `/signup`, "Pricing" → `/pricing`, "Log in", "Start free". Footer links to pricing/terms/privacy/login |
+| A1 | Open `/` logged out | Landing renders. Header: "For accountants" → `/signup/accountants`, "Pricing" → `/pricing`, "Log in", "Start free". Footer links to pricing/terms/privacy/login |
 | A2 | Open `/login`, `/signup`, `/forgot-password`, `/offline` logged out | All render (public) |
 | A3 | Open `/home` (or any app URL) logged out | Redirect to `/login` |
-| A4 | Open `/pricing`, `/terms`, `/privacy` logged out | **Currently redirects to `/login`** — known issue #5 (§Known issues): legal/pricing pages aren't in the public path list. Log it if not yet fixed; also note the signup consent links open these in a new tab and bounce |
+| A4 | Open `/pricing`, `/terms`, `/privacy` logged out | All render publicly (fixed — was https://github.com/louissullivan4/airgead/issues/8)
 | A5 | Log in, then open `/` or `/login` | Redirect to `/home` |
 | A6 | `/health` on the backend (`curl localhost:8080/health`) | 200, no auth needed |
 
@@ -88,10 +88,10 @@ Personas without seed accounts — create during Suite B: **P1 solo trader** (fr
 | B1 | `/signup`: fill first/surname/email/password, leave "Set up your organisation" collapsed, tick consent, submit | Lands on `/home`. Personal org auto-named "Fname Sname", nav shows only Home/Transactions/Settings (P1). Currency EUR |
 | B2 | Same but submit **without** ticking consent | Button disabled; if forced, error "Please agree to the Terms of Service and Privacy Policy to continue." |
 | B3 | Expand "Add details": org name "QA Bakery", type Hospitality, country IE, VAT number | Business org created; nav now includes Tax summary + Team (P2). Settings → Organisation shows the entered values |
-| B4 | Expand "Add details", tick **"This is an accountancy practice"**, name the org, submit | New firm: Clients appears in nav; Team page says "Accountants" |
-| B5 | Repeat B4 but leave org name **blank** | **Known issue #3**: practice checkbox silently ignored — user gets a personal org, no Clients nav. Log if unfixed |
+| B4 | Open `/signup/accountants` (linked from the landing "For accountants" and from the main signup), fill practice name, submit | New firm: Clients appears in nav; Team page says "Accountants". The practice checkbox is gone from `/signup` — practices sign up on the dedicated page (fixed — was https://github.com/louissullivan4/airgead/issues/9) |
+| B5 | On `/signup` expand "Add details" and leave org name **blank**; on `/signup/accountants` leave practice name **blank** | Submit blocked with inline "Organisation name is required." / "Practice name is required." — org details are never silently dropped (fixed — was known issue #3, https://github.com/louissullivan4/airgead/issues/10) |
 | B6 | Sign up with an email that already exists | 400 "User with this email already exists." shown inline |
-| B7 | Sign up with a 1-character password | **Currently accepted** (no strength rules — known issue #2). Verify hint text says "At least 8 characters" but nothing enforces it |
+| B7 | Sign up with a weak password | Blocked: live checklist (8+ chars, lower, upper, number, symbol), retype field with mismatch error, reveal toggles on both inputs. The register and reset endpoints enforce the same rules server-side (fixed — was known issue #2, https://github.com/louissullivan4/airgead/issues/11) |
 
 **B8–B11 invite signups** (need SMTP or token from logs; all invite links = `/signup?token=…`, valid 7 days, invitee auto-verified, org section hidden on the signup page):
 
@@ -117,8 +117,8 @@ Personas without seed accounts — create during Suite B: **P1 solo trader** (fr
 | C9 | Use the resend button / `POST /users/resend-verification` with any email | Always 200 "If that address needs verification, a new link is on its way." (no user enumeration) |
 | C10 | Open an **expired/invalid** verification link | Redirect `/login?verified=expired` → error text prompting a new link |
 | C11 | `/forgot-password` with a seeded email | Success screen "If an account exists for {email}, a reset link is on its way." |
-| C12 | `/forgot-password` with an unknown email | **Known issue #4**: shows "User not found." (enumeration leak). Log if unfixed |
-| C13 | Open the emailed reset link `/reset-password?token=…` | **Known issue #1**: page does not exist → 404. The backend endpoint works but has no UI. Log if unfixed |
+| C12 | `/forgot-password` with an unknown email | Same success screen as C11 — 200 with the generic message, no email sent (fixed — was known issue #4) |
+| C13 | Open the emailed reset link `/reset-password?token=…` | Page renders with the same password-rules UX as signup. Expired/invalid token → 400 "This reset link is invalid or has expired - request a new one." with a link to request a fresh one (fixed — was known issue #1) |
 
 ## Suite D — Core capture & transactions (run as P1; spot-check as P6a which has seed data)
 
@@ -126,7 +126,7 @@ Personas without seed accounts — create during Suite B: **P1 solo trader** (fr
 |---|---|---|
 | D1 | `/home` on a fresh account | Stat cards all €0.00 / 0; "No expenses recorded for {year} yet."; "No transactions yet" empty state with Add button |
 | D2 | Add → **camera dialog** appears; click "Take a photo" on desktop | File picker opens (mobile: camera). Pick a receipt photo → spinner "Cleaning up receipt…" (dialog can't be closed) → form opens in **Receipt mode** with thumbnail |
-| D3 | Receipt mode: set merchant, add 2 line items (category + amount each), save | Toast "2 items added". Two rows appear sharing one receipt icon. Home Receipts counter: see known issue #7 (captured receipts don't increment it) |
+| D3 | Receipt mode: set merchant, add 2 line items (category + amount each), save | Toast "2 items added". Two rows appear sharing one receipt icon. Home Receipts counter +1 (multi-line captures count once; fixed — was known issue #7) |
 | D4 | Receipt mode: try saving a line without category or with amount 0 | Toast "Each line needs a category and a non-zero amount." |
 | D5 | Add → **Skip photo** | Blank single form. Save an expense (title, category, amount, date) → row appears |
 | D6 | Add an **Income** entry (type toggle) | No category/capital UI; renders green `+` amount; Home Income card updates |
@@ -138,7 +138,7 @@ Personas without seed accounts — create during Suite B: **P1 solo trader** (fr
 | D12 | Receipt thumbnail click | Full image opens in new tab (signed URL). Re-open after >5 min idle: link in old tab expires (403 from storage), re-rendered thumb re-signs |
 | D13 | **Capital toggle**: add expense with category "Equipment" (or any capital-flagged) | Toggle pre-ticks; Asset type select appears. After save: **Capital chip** on the row; asset on `/reports` register as "From transaction" |
 | D14 | Edit that expense, untick Capital | Chip gone; asset removed from register; transaction remains |
-| D15 | Header **Export** | Downloads `transactions_{year}.zip` (xlsx + images/). On a no-data year: toast shows generic "Not Found" — known issue #6 |
+| D15 | Header **Export** | Downloads `transactions_{year}.zip` (xlsx + images/). On a no-data year: toast shows "No expenses found for the given user and year." (fixed — was known issue #6) |
 | D16 | Categories select in the form | Shows the org's tree (groups + indented children). For P6a expect the equine template |
 
 ## Suite E — Business-owner extras (run as P2 or P6b)
@@ -179,7 +179,7 @@ Personas without seed accounts — create during Suite B: **P1 solo trader** (fr
 | G4 | Open a client → detail page | "Viewing {name} · read-only" bar; Transactions tab with filter/sort/pagination; no edit/delete controls anywhere |
 | G5 | Client detail → Tax summary tab + year picker | Loads the client's summary; year change refetches |
 | G6 | Export (list row or detail) | Downloads zip: `transactions_{year}.xlsx` (Expenses sheet + Tax summary + Capital allowances + VAT sheets, Capital column, embedded images) + `images/` |
-| G7 | Export a client with no transactions this year | Toast error (404 path) |
+| G7 | Export a client with no transactions this year | Toast "No transactions found for the given client and year." (fixed — was known issue #6) |
 | G8 | Invite client (fresh email) → complete signup | New client org appears in list, owned by P4 (Accountant column) |
 | G9 | **Reassign** (row menu, admin only) → pick the staff accountant | Success toast; Accountant column updates; P5 can now see it |
 | G10 | **Revoke access** on a test client → confirm | Client disappears from list. Their login/data unaffected (verify by logging in as them). Re-invite works afterwards |
@@ -214,8 +214,8 @@ Personas without seed accounts — create during Suite B: **P1 solo trader** (fr
 | J2 | Orgs table | All orgs, member counts, year stats, status. Own org row: only "Open" (no suspend/delete) |
 | J3 | Users table | All users with org, platform pill. Own row: no actions menu |
 | J4 | Grant super admin to a test user → verify → revoke | PATCH works; target sees Admin nav on next login. Attempting on own id → 400 |
-| J5 | **Suspend a user** → they log out & retry login | 403 "This account has been suspended." — **but an existing session keeps working until the 7-day token expires (known behaviour #8)** |
-| J6 | **Suspend an org** → its members' fresh logins | 403 "This organisation has been suspended." Same live-session caveat |
+| J5 | **Suspend a user** → they log out & retry login | 403 "This account has been suspended." Existing sessions are cut off too — their next API call answers 403 (fixed — was known behaviour #8) |
+| J6 | **Suspend an org** → its members' fresh logins | 403 "This organisation has been suspended." Members' live sessions also blocked on their next API call |
 | J7 | GDPR delete: a member user | User + their expenses/receipts gone; org survives; any client links they created lose their owner (firm admin still sees the client) |
 | J8 | GDPR delete: a user who solely owns an org | Cascades the whole org. If the org has other members → 409 "…Delete the organisation or reassign ownership first." |
 | J9 | Delete an org (not your own) | Cascade removes links/users/data. Own org → 400 |
@@ -306,13 +306,15 @@ Restart backend with `BILLING_ENFORCED=true`. Create a fresh solo signup (it get
 
 ## Known issues (log as pre-existing; verify status before filing duplicates)
 
-1. **`/reset-password` page missing** — the emailed reset link 404s; backend endpoint exists but has no UI (C13).
-2. **No password rules enforced** — 1-char passwords accepted at signup and reset (B7).
-3. **Practice checkbox ignored when org name blank** at signup — user silently gets a personal org (B5).
-4. **Forgot-password reveals account existence** — "User not found." for unknown emails; resend-verification is enumeration-safe by contrast (C12).
-5. **`/pricing`, `/terms`, `/privacy` blocked for logged-out visitors** — middleware only allows `/`, auth paths, `/offline` (A4).
-6. **Export "no data" toast shows generic "Not Found"** — backend sends `{message}` but the client only reads `{error}` (D15, G7).
-7. **Home "Receipts" stat undercounts** — camera-captured receipts (receipt_id on the expense, `receipt_image_url` null) don't increment it; only legacy uploads do (D3).
-8. **Suspension doesn't kill live sessions** — enforced at login only; a suspended user's existing 7-day token keeps working (J5/J6).
-9. **"For accountants" landing link** goes to plain `/signup`, not a dedicated page (A1) — confirm this is intended.
-10. **Winston boot warnings print `%s` un-interpolated** in `Env check:` lines — cosmetic, but hides which env var the warning is about (L4).
+All ten issues from the previous pass are **fixed** (2026-07-04). Original entries kept for reference — re-verify via the cases in brackets:
+
+1. ~~**`/reset-password` page missing**~~ — Fixed: page exists with the shared password-rules UX; bad/expired tokens get an actionable 400 (C13).
+2. ~~**No password rules enforced**~~ — Fixed: signup/reset enforce 8+ chars, lower, upper, number, symbol client- AND server-side, with confirm field + reveal toggles (B7).
+3. ~~**Practice checkbox ignored when org name blank**~~ — Fixed: org/practice name is required whenever the section is open; the checkbox itself is gone (see 9) (B5).
+4. ~~**Forgot-password reveals account existence**~~ — Fixed: always 200 with the generic message, matching resend-verification (C12).
+5. ~~**`/pricing`, `/terms`, `/privacy` blocked for logged-out visitors**~~ — Fixed: `PUBLIC_PATHS` allow-list in the middleware (A4).
+6. ~~**Export "no data" toast shows generic "Not Found"**~~ — Fixed: backend answers `{error}` and the client also falls back to `{message}` (D15, G7).
+7. ~~**Home "Receipts" stat undercounts**~~ — Fixed: counts distinct captured receipts (`receipt_id`) plus legacy uploads (D3).
+8. ~~**Suspension doesn't kill live sessions**~~ — Fixed: auth middleware checks user/org status per request; deleted accounts also 401 immediately (J5/J6).
+9. ~~**"For accountants" landing link goes to plain `/signup`**~~ — Fixed: dedicated `/signup/accountants` page (practice name required, no business type); the practice checkbox was removed from `/signup`, which now cross-links to it (A1, B4).
+10. ~~**Winston boot warnings print `%s` un-interpolated**~~ — Fixed: `format.splat()` added to the logger, so all `%s`/`%o` placeholders interpolate (L4).

--- a/frontend/src/app/(app)/home/page.tsx
+++ b/frontend/src/app/(app)/home/page.tsx
@@ -62,7 +62,11 @@ export default function HomePage() {
   const { income, expensesTotal, net, receiptCount, byCategory, recent } = useMemo(() => {
     let income = 0;
     let expensesTotal = 0;
-    let receiptCount = 0;
+    // Camera captures store the image on a shared receipts row (receipt_id,
+    // possibly across several line items), legacy uploads on the expense
+    // itself (receipt_image_url) - count distinct receipts across both.
+    let legacyReceiptCount = 0;
+    const receiptIds = new Set<string>();
     const categoryMap = new Map<string, number>();
 
     for (const e of expenses) {
@@ -73,8 +77,13 @@ export default function HomePage() {
         expensesTotal += amount;
         categoryMap.set(e.category, (categoryMap.get(e.category) ?? 0) + amount);
       }
-      if (e.receipt_image_url) receiptCount += 1;
+      if (e.receipt_id) {
+        receiptIds.add(e.receipt_id);
+      } else if (e.receipt_image_url) {
+        legacyReceiptCount += 1;
+      }
     }
+    const receiptCount = receiptIds.size + legacyReceiptCount;
 
     const byCategory = Array.from(categoryMap, ([category, value]) => ({ category, value }));
     const recent = [...expenses]

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Suspense, useState, type FormEvent } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { KeyRound } from "lucide-react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { PasswordFields, passwordMeetsRules } from "@/components/password-fields";
+import { Spinner } from "@/components/ui/spinner";
+
+// The page behind the emailed reset link (/reset-password?token=…). The token
+// is only valid for 1 hour; a failed submit points back to /forgot-password
+// for a fresh one.
+function ResetPasswordForm() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!passwordMeetsRules(password)) {
+      setError("Your password does not meet all the requirements listed below it.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setLoading(true);
+    try {
+      await api.users.resetPassword(token as string, password);
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">Reset link missing</h1>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          This page only works from the link in a password-reset email. Request a new one below.
+        </p>
+        <Button asChild className="mt-8 w-full">
+          <Link href="/forgot-password">Request a reset link</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (done) {
+    return (
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full bg-success/10">
+          <KeyRound className="size-6 text-success" />
+        </div>
+        <h1 className="text-2xl font-semibold tracking-tight">Password updated</h1>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          You can now sign in with your new password.
+        </p>
+        <Button asChild className="mt-8 w-full">
+          <Link href="/login">Sign in</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold tracking-tight">Choose a new password</h1>
+      <p className="mt-1.5 text-sm text-muted-foreground">
+        Set a new password for your account to finish the reset.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-8 space-y-4">
+        {error && (
+          <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm font-medium text-destructive">
+            {error}
+          </p>
+        )}
+        <PasswordFields
+          password={password}
+          confirmPassword={confirmPassword}
+          onPasswordChange={setPassword}
+          onConfirmPasswordChange={setConfirmPassword}
+        />
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading && <Spinner />}
+          {loading ? "Updating…" : "Update password"}
+        </Button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-muted-foreground">
+        Link expired?{" "}
+        <Link href="/forgot-password" className="font-medium text-primary hover:underline">
+          Request a new one
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={null}>
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/(auth)/signup/accountants/page.tsx
+++ b/frontend/src/app/(auth)/signup/accountants/page.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { api } from "@/lib/api";
+import { BRAND } from "@/lib/brand";
+import { COUNTRIES, DEFAULT_COUNTRY } from "@/lib/org";
+import { Button } from "@/components/ui/button";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { PasswordFields, passwordMeetsRules } from "@/components/password-fields";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+
+// Dedicated signup for accountancy practices (linked from the landing page's
+// "For accountants" and from the main signup). Always creates a practice org
+// (is_accountant_practice), so there is no business-type picker here and the
+// practice name is mandatory - unlike the optional org section on /signup.
+export default function AccountantSignupPage() {
+  const router = useRouter();
+
+  const [fname, setFname] = useState("");
+  const [sname, setSname] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [consent, setConsent] = useState(false);
+
+  const [practiceName, setPracticeName] = useState("");
+  const [practiceNameError, setPracticeNameError] = useState<string | null>(null);
+  const [practiceDescription, setPracticeDescription] = useState("");
+  const [country, setCountry] = useState(DEFAULT_COUNTRY);
+  const [vatNumber, setVatNumber] = useState("");
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setPracticeNameError(null);
+    if (!consent) {
+      setError("Please agree to the Terms of Service and Privacy Policy to continue.");
+      return;
+    }
+    if (!passwordMeetsRules(password)) {
+      setError("Your password does not meet all the requirements listed below it.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+    if (!practiceName.trim()) {
+      setPracticeNameError("Practice name is required.");
+      return;
+    }
+    setLoading(true);
+    try {
+      await api.auth.register({
+        fname,
+        sname,
+        email,
+        password,
+        currency: "EUR",
+        organisation: {
+          name: practiceName.trim(),
+          description: practiceDescription.trim() || undefined,
+          country,
+          vat_number: country === "IE" && vatNumber.trim() ? vatNumber.trim() : undefined,
+          is_accountant_practice: true,
+        },
+      });
+      router.push("/home");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Signup failed");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold tracking-tight">Create your practice</h1>
+      <p className="mt-1.5 text-sm text-muted-foreground">
+        {`For accountancy practices: manage your clients' books with ${BRAND} - invite clients, review their records, and export tax-ready packs.`}
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-8 space-y-4">
+        {error && (
+          <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm font-medium text-destructive">
+            {error}
+          </p>
+        )}
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="First name" htmlFor="fname">
+            <Input
+              id="fname"
+              autoComplete="given-name"
+              value={fname}
+              onChange={(e) => setFname(e.target.value)}
+              required
+            />
+          </Field>
+          <Field label="Surname" htmlFor="sname">
+            <Input
+              id="sname"
+              autoComplete="family-name"
+              value={sname}
+              onChange={(e) => setSname(e.target.value)}
+              required
+            />
+          </Field>
+        </div>
+        <Field label="Email" htmlFor="email">
+          <Input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </Field>
+        <PasswordFields
+          password={password}
+          confirmPassword={confirmPassword}
+          onPasswordChange={setPassword}
+          onConfirmPasswordChange={setConfirmPassword}
+        />
+
+        <div className="space-y-4 rounded-lg border border-border p-4">
+          <div>
+            <p className="text-sm font-medium">Your practice</p>
+            <p className="text-xs text-muted-foreground">
+              Unlocks the Clients workspace to invite and oversee client organisations.
+            </p>
+          </div>
+          <Field
+            label="Practice name"
+            htmlFor="practice-name"
+            required
+            error={practiceNameError ?? undefined}
+          >
+            <Input
+              id="practice-name"
+              value={practiceName}
+              onChange={(e) => {
+                setPracticeName(e.target.value);
+                setPracticeNameError(null);
+              }}
+              placeholder="e.g. Sullivan & Co. Accountants"
+              aria-invalid={practiceNameError ? true : undefined}
+              required
+            />
+          </Field>
+          <Field label="Description" htmlFor="practice-description" hint="Optional">
+            <Textarea
+              id="practice-description"
+              rows={2}
+              value={practiceDescription}
+              onChange={(e) => setPracticeDescription(e.target.value)}
+              placeholder="What does your practice specialise in?"
+            />
+          </Field>
+          <div className="grid grid-cols-2 gap-3">
+            <Field label="Country" htmlFor="practice-country">
+              <Select value={country} onValueChange={setCountry}>
+                <SelectTrigger id="practice-country">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {COUNTRIES.map((c) => (
+                    <SelectItem key={c.code} value={c.code}>
+                      {c.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+            {country === "IE" && (
+              <Field label="VAT number" htmlFor="practice-vat" hint="Optional">
+                <Input
+                  id="practice-vat"
+                  value={vatNumber}
+                  onChange={(e) => setVatNumber(e.target.value)}
+                  placeholder="IE1234567T"
+                />
+              </Field>
+            )}
+          </div>
+        </div>
+
+        <label htmlFor="consent" className="flex cursor-pointer items-start gap-3 text-sm">
+          <input
+            id="consent"
+            type="checkbox"
+            checked={consent}
+            onChange={(e) => setConsent(e.target.checked)}
+            className="mt-0.5 size-4 accent-primary"
+            required
+          />
+          <span className="text-muted-foreground">
+            I agree to the{" "}
+            <Link
+              href="/terms"
+              target="_blank"
+              className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
+            >
+              Terms of Service
+            </Link>{" "}
+            and{" "}
+            <Link
+              href="/privacy"
+              target="_blank"
+              className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
+            >
+              Privacy Policy
+            </Link>
+            .
+          </span>
+        </label>
+
+        <Button type="submit" className="w-full" disabled={loading || !consent}>
+          {loading && <Spinner />}
+          {loading ? "Creating practice…" : "Create practice"}
+        </Button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-muted-foreground">
+        Not an accountancy practice?{" "}
+        <Link href="/signup" className="font-medium text-primary hover:underline">
+          Sign up here
+        </Link>
+      </p>
+      <p className="mt-2 text-center text-sm text-muted-foreground">
+        Already have an account?{" "}
+        <Link href="/login" className="font-medium text-primary hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -9,6 +9,7 @@ import { COUNTRIES, DEFAULT_COUNTRY, ORG_CATEGORIES } from "@/lib/org";
 import { Button } from "@/components/ui/button";
 import { Field } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { PasswordFields, passwordMeetsRules } from "@/components/password-fields";
 import {
   Select,
   SelectContent,
@@ -28,6 +29,7 @@ function SignupForm() {
   const [sname, setSname] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Consent is required; the timestamp of acceptance IS the account-creation
@@ -35,28 +37,45 @@ function SignupForm() {
   const [consent, setConsent] = useState(false);
 
   // Optional org-creation step (self-serve only). Invitees join the inviter's
-  // org, so the section is hidden for them.
+  // org, so the section is hidden for them. Accountancy practices sign up on
+  // /signup/accountants instead - this form only creates normal orgs.
   const [showOrg, setShowOrg] = useState(false);
   const [orgName, setOrgName] = useState("");
   const [orgDescription, setOrgDescription] = useState("");
   const [orgCountry, setOrgCountry] = useState(DEFAULT_COUNTRY);
   const [orgVat, setOrgVat] = useState("");
   const [orgCategory, setOrgCategory] = useState("");
-  const [isPractice, setIsPractice] = useState(false);
+  const [orgNameError, setOrgNameError] = useState<string | null>(null);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
+    setOrgNameError(null);
     if (!consent) {
       setError("Please agree to the Terms of Service and Privacy Policy to continue.");
+      return;
+    }
+    if (!passwordMeetsRules(password)) {
+      setError("Your password does not meet all the requirements listed below it.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+    // The org section silently produced no payload on a blank name (the
+    // backend then auto-creates a personal org, discarding the details) - so
+    // a name is required whenever the section is open.
+    if (!inviteToken && showOrg && !orgName.trim()) {
+      setOrgNameError("Organisation name is required.");
       return;
     }
     setLoading(true);
     try {
       // Currency defaults to EUR; address/occupation/tax details are collected
       // later in Settings to keep signup short. The organisation is sent only
-      // when the user opened the section and named it - otherwise the backend
-      // auto-creates a personal org.
+      // when the user opened the section (the validation above guarantees it
+      // is named) - otherwise the backend auto-creates a personal org.
       const organisation =
         !inviteToken && showOrg && orgName.trim()
           ? {
@@ -66,7 +85,6 @@ function SignupForm() {
               vat_number:
                 orgCountry === "IE" && orgVat.trim() ? orgVat.trim() : undefined,
               org_category: orgCategory || undefined,
-              is_accountant_practice: isPractice || undefined,
             }
           : undefined;
       await api.auth.register({
@@ -131,16 +149,12 @@ function SignupForm() {
             required
           />
         </Field>
-        <Field label="Password" htmlFor="password" hint="At least 8 characters.">
-          <Input
-            id="password"
-            type="password"
-            autoComplete="new-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </Field>
+        <PasswordFields
+          password={password}
+          confirmPassword={confirmPassword}
+          onPasswordChange={setPassword}
+          onConfirmPasswordChange={setConfirmPassword}
+        />
 
         {!inviteToken && (
           <div className="rounded-lg border border-border p-4">
@@ -163,31 +177,22 @@ function SignupForm() {
 
             {showOrg && (
               <div className="mt-4 space-y-4">
-                <label
-                  htmlFor="org-practice"
-                  className="flex cursor-pointer items-start gap-3 rounded-lg border border-border bg-muted/30 p-3"
+                <Field
+                  label="Organisation name"
+                  htmlFor="org-name"
+                  required
+                  error={orgNameError ?? undefined}
                 >
-                  <input
-                    id="org-practice"
-                    type="checkbox"
-                    checked={isPractice}
-                    onChange={(e) => setIsPractice(e.target.checked)}
-                    className="mt-0.5 size-4 accent-primary"
-                  />
-                  <span className="text-sm">
-                    <span className="font-medium">This is an accountancy practice</span>
-                    <span className="block text-xs text-muted-foreground">
-                      I manage other people&apos;s books. Unlocks the Clients workspace to invite and
-                      oversee client organisations.
-                    </span>
-                  </span>
-                </label>
-                <Field label="Organisation name" htmlFor="org-name">
                   <Input
                     id="org-name"
                     value={orgName}
-                    onChange={(e) => setOrgName(e.target.value)}
+                    onChange={(e) => {
+                      setOrgName(e.target.value);
+                      setOrgNameError(null);
+                    }}
                     placeholder="e.g. Galway Equine"
+                    aria-invalid={orgNameError ? true : undefined}
+                    required
                   />
                 </Field>
                 <Field label="Description" htmlFor="org-description" hint="Optional">
@@ -241,6 +246,17 @@ function SignupForm() {
                 </div>
               </div>
             )}
+
+            <p className="mt-3 text-xs text-muted-foreground">
+              Running an accountancy practice?{" "}
+              <Link
+                href="/signup/accountants"
+                className="font-medium text-primary hover:underline"
+              >
+                Use the accountant signup
+              </Link>{" "}
+              to manage your clients&apos; books.
+            </p>
           </div>
         )}
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -58,7 +58,7 @@ export default async function LandingPage() {
           <Logo href="/" />
           <div className="flex items-center gap-2">
             <Button asChild variant="ghost" size="sm" className="hidden sm:inline-flex">
-              <Link href="/signup">For accountants</Link>
+              <Link href="/signup/accountants">For accountants</Link>
             </Button>
             <Button asChild variant="ghost" size="sm" className="hidden sm:inline-flex">
               <Link href="/pricing">Pricing</Link>

--- a/frontend/src/components/password-fields.tsx
+++ b/frontend/src/components/password-fields.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Eye, EyeOff, X } from "lucide-react";
+import { Field } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+// Password strength rules, shown as a live checklist under the field. The
+// register and reset endpoints enforce the same rules server-side (client
+// checks alone are bypassable via a direct API call).
+export const PASSWORD_RULES: { label: string; test: (pw: string) => boolean }[] = [
+  { label: "At least 8 characters", test: (pw) => pw.length >= 8 },
+  { label: "One lowercase letter", test: (pw) => /[a-z]/.test(pw) },
+  { label: "One uppercase letter", test: (pw) => /[A-Z]/.test(pw) },
+  { label: "One number", test: (pw) => /[0-9]/.test(pw) },
+  { label: "One symbol", test: (pw) => /[^A-Za-z0-9]/.test(pw) },
+];
+
+export const passwordMeetsRules = (password: string) =>
+  PASSWORD_RULES.every((rule) => rule.test(password));
+
+function RevealToggle({ shown, onToggle }: { shown: boolean; onToggle: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={shown ? "Hide password" : "Show password"}
+      className="absolute inset-y-0 right-0 flex items-center px-3 text-muted-foreground transition-colors hover:text-foreground"
+    >
+      {shown ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+    </button>
+  );
+}
+
+/**
+ * Password + retype fields with reveal toggles, a live rules checklist and an
+ * inline mismatch error. Shared by signup (both variants) and reset-password
+ * so the password UX stays identical everywhere.
+ */
+export function PasswordFields({
+  password,
+  confirmPassword,
+  onPasswordChange,
+  onConfirmPasswordChange,
+}: {
+  password: string;
+  confirmPassword: string;
+  onPasswordChange: (value: string) => void;
+  onConfirmPasswordChange: (value: string) => void;
+}) {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const mismatch = confirmPassword.length > 0 && password !== confirmPassword;
+
+  return (
+    <>
+      <Field label="Password" htmlFor="password">
+        <div className="relative">
+          <Input
+            id="password"
+            type={showPassword ? "text" : "password"}
+            autoComplete="new-password"
+            className="pr-10"
+            value={password}
+            onChange={(e) => onPasswordChange(e.target.value)}
+            required
+          />
+          <RevealToggle shown={showPassword} onToggle={() => setShowPassword((v) => !v)} />
+        </div>
+        <ul className="mt-1 grid grid-cols-1 gap-1 sm:grid-cols-2" aria-live="polite">
+          {PASSWORD_RULES.map((rule) => {
+            const met = rule.test(password);
+            return (
+              <li
+                key={rule.label}
+                className={`flex items-center gap-1.5 text-xs ${
+                  met ? "text-primary" : "text-muted-foreground"
+                }`}
+              >
+                {met ? <Check className="size-3 shrink-0" /> : <X className="size-3 shrink-0" />}
+                {rule.label}
+              </li>
+            );
+          })}
+        </ul>
+      </Field>
+      <Field
+        label="Retype password"
+        htmlFor="confirm-password"
+        error={mismatch ? "Passwords do not match." : undefined}
+      >
+        <div className="relative">
+          <Input
+            id="confirm-password"
+            type={showConfirm ? "text" : "password"}
+            autoComplete="new-password"
+            className="pr-10"
+            value={confirmPassword}
+            onChange={(e) => onConfirmPasswordChange(e.target.value)}
+            aria-invalid={mismatch || undefined}
+            required
+          />
+          <RevealToggle shown={showConfirm} onToggle={() => setShowConfirm((v) => !v)} />
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,8 +22,16 @@ export class ApiError extends Error {
 }
 
 async function parseError(res: Response): Promise<{ message: string; code?: string }> {
-  const body = (await res.json().catch(() => null)) as { error?: string; code?: string } | null;
-  return { message: body?.error ?? res.statusText ?? "Request failed", code: body?.code };
+  const body = (await res.json().catch(() => null)) as {
+    error?: string;
+    // A few legacy endpoints answer { message } instead of { error }.
+    message?: string;
+    code?: string;
+  } | null;
+  return {
+    message: body?.error ?? body?.message ?? res.statusText ?? "Request failed",
+    code: body?.code,
+  };
 }
 
 // A 401 from the proxy means the session is gone (logged out, expired, or the
@@ -98,6 +106,12 @@ export const api = {
       request<void>("/users/request-password-reset", {
         method: "POST",
         body: JSON.stringify({ email }),
+      }),
+    /** Complete a password reset with the token from the emailed link. */
+    resetPassword: (token: string, newPassword: string) =>
+      request<void>("/users/reset-password", {
+        method: "POST",
+        body: JSON.stringify({ token, newPassword }),
       }),
     /** Re-send the email-verification link (rate-limited; never confirms account existence). */
     resendVerification: (email: string) =>
@@ -678,6 +692,8 @@ export interface OrganisationInput {
   type?: "personal" | "business";
   org_category?: string;
   vat_status?: VatStatus;
+  /** Marks the org as an accountancy practice (set by /signup/accountants). */
+  is_accountant_practice?: boolean;
 }
 
 /** Organisation row returned by the backend. */

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -6,6 +6,11 @@ export const TOKEN_COOKIE = "airgead_token";
 // Pages reachable without a session. Everything else requires the auth cookie.
 export const AUTH_PATHS = ["/login", "/signup", "/forgot-password", "/reset-password"];
 
+// Public marketing/legal pages, reachable in any auth state. Linked from the
+// landing header/footer and the signup consent text, so logged-out visitors
+// must be able to read them.
+export const PUBLIC_PATHS = ["/pricing", "/terms", "/privacy"];
+
 // Phase 2 OCR auto-fill feature flag. DORMANT by default: when false, the camera
 // capture flow goes straight to the manual form - no OCR auto-fill UI renders and
 // no parsed data is used. Mirror of the backend OCR_PROVIDER/OCR_AUTOFILL_ENABLED

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { TOKEN_COOKIE, AUTH_PATHS } from "@/lib/constants";
+import { TOKEN_COOKIE, AUTH_PATHS, PUBLIC_PATHS } from "@/lib/constants";
 
 // Route guard: unauthenticated users may see the public landing page ("/") and
 // the auth pages; everything else redirects to /login. Authenticated users
@@ -13,11 +13,15 @@ export function middleware(req: NextRequest) {
   );
   // The marketing landing page at "/" is publicly accessible.
   const isLanding = pathname === "/";
+  // Marketing/legal pages (pricing, terms, privacy) are public in any auth state.
+  const isPublic = PUBLIC_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
 
   // The offline fallback must be reachable by anyone, in any auth state.
   if (pathname === "/offline") return NextResponse.next();
 
-  if (!hasToken && !isAuthPath && !isLanding) {
+  if (!hasToken && !isAuthPath && !isLanding && !isPublic) {
     const url = req.nextUrl.clone();
     url.pathname = "/login";
     return NextResponse.redirect(url);


### PR DESCRIPTION
Fixes every open QA finding: the five filed GitHub issues plus the remaining items from the Known issues list in `docs/qa-test-plan.md`.

## Linked issues

- Closes #8 — `/pricing`, `/terms`, `/privacy` now public via a `PUBLIC_PATHS` allow-list in the middleware
- Closes #9 — dedicated `/signup/accountants` page (practice name required, no business-type picker, always creates a practice). The practice checkbox is removed from `/signup`, which cross-links to the new page; the landing "For accountants" button points at it
- Closes #10 — organisation/practice name is required whenever the org section is open, with an inline error instead of silently dropping the org payload
- Closes #11 — password confirmation field, live strength checklist (8+ chars, lower, upper, number, symbol) and reveal toggles; the same policy is enforced server-side on `register` and `reset-password`
- Closes #12 — all transactional emails (invites, verification, password reset, support) share one branded HTML layout (`backend/src/utils/email.js`) matching the app theme, with plaintext fallbacks

## QA-plan known issues also fixed

| # | Fix |
|---|---|
| 1 | New `/reset-password` page consuming the emailed token; expired/invalid tokens answer 400 with an actionable message |
| 4 | Forgot-password always answers 200 with a generic message (no account enumeration) |
| 6 | Export "no data" 404s send `{error}`; client also falls back to `{message}` |
| 7 | Home Receipts stat counts captured receipts (distinct `receipt_id`) plus legacy uploads |
| 8 | User/org suspension enforced per request in the auth middleware; deleted accounts 401 immediately (fails open on DB errors) |
| 10 | `format.splat()` added to the winston logger so `%s`/`%o` interpolate app-wide |

The shared password UX lives in `frontend/src/components/password-fields.tsx` (used by both signup variants and reset-password). `docs/qa-test-plan.md` is updated so the affected cases and the Known issues list describe the fixed behaviour.

## Verification

- Backend: 232/232 jest tests pass (5 new tests cover per-request suspension), ESLint clean
- Frontend: `next build` compiles with no type errors; new routes `/reset-password` and `/signup/accountants` present
- Email renderer smoke-tested for HTML escaping and URL encoding
