### PR TITLE
ci: add dependabot, Trivy image scan, dependency review, hadolint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  # Minor/patch bumps arrive as one grouped PR per directory; majors come individually.
+  - package-ecosystem: npm
+    directories:
+      - '/'
+      - '/backend'
+      - '/frontend'
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,33 @@ jobs:
           node-version: '20'
       - run: npm run check:brand --workspace=backend
 
+  hadolint:
+    name: Dockerfile Lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dockerfile: [backend/Dockerfile, frontend/Dockerfile]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: ${{ matrix.dockerfile }}
+
+  # Blocks PRs that introduce a dependency with a known vulnerability.
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/dependency-review-action@v5
+
   # ── Build & push images (main only) ───────────────────────────────────────
 
   docker-backend:
     name: Docker - Backend
     if: github.event_name == 'push'
-    needs: [lint, test, build-frontend, brand]
+    needs: [lint, test, build-frontend, brand, hadolint]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -125,7 +146,7 @@ jobs:
   docker-frontend:
     name: Docker - Frontend
     if: github.event_name == 'push'
-    needs: [lint, test, build-frontend, brand]
+    needs: [lint, test, build-frontend, brand, hadolint]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -147,6 +168,38 @@ jobs:
             ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,scope=frontend,mode=max
+
+  # Base-image CVEs are invisible to Dependabot/CodeQL; findings land in the
+  # Security tab. Non-blocking: deploys do not wait on this job.
+  scan-images:
+    name: Image Scan (Trivy)
+    if: github.event_name == 'push'
+    needs: [docker-backend, docker-frontend]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      matrix:
+        image: [backend, frontend]
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.image }}:${{ github.sha }}
+          format: sarif
+          output: trivy-${{ matrix.image }}.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+      - uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-${{ matrix.image }}.sarif
+          category: trivy-${{ matrix.image }}
 
   migrate-test:
     name: Run Migrations (test)

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,3 @@
+ignored:
+  # Pinned apk packages disappear from Alpine mirrors and break builds.
+  - DL3018


### PR DESCRIPTION
Implements docs/addons.md:

- **dependabot.yml** — weekly npm updates for root/backend/frontend with minor+patch grouped into one PR per directory (majors arrive individually), plus github-actions version updates.
- **Trivy image scan** — scans both pushed GHCR images (CRITICAL/HIGH, fixed-only) after the docker builds and uploads SARIF, so base-image CVEs land in the Security tab next to CodeQL. Runs in parallel with the deploy chain and never blocks it. Only runs on push to main, so it will not appear in this PR's checks.
- **dependency-review-action** — blocks PRs that introduce a dependency with a known vulnerability.
- **hadolint** — lints both Dockerfiles and gates the image builds. DL3018 (pin apk versions) is ignored via .hadolint.yaml since pinned Alpine packages rot off the mirrors.

The dependency-review and hadolint jobs run on this PR itself, so passing checks here validates them.